### PR TITLE
修复拉取的数据不完整时无法刷新的异常，提升刷新优先级，优化轻量加载逻辑

### DIFF
--- a/script/lorainfo.py
+++ b/script/lorainfo.py
@@ -162,12 +162,21 @@ async def get_loras_info_response(request, maybe_fetch_civitai=False, maybe_fetc
   """Gets lora info for all or a single lora"""
   api_response = {'status': 200}
   lora_file = get_param(request, 'file')
-  light = not is_param_falsy(request, 'light')
+  if get_param(request, 'light') is not None:
+    light = is_param_falsy(request, 'light')
+  else:
+    light = False
   if lora_file is not None:
-    info_data = await get_model_info(lora_file,
-                                     maybe_fetch_civitai=maybe_fetch_civitai,
-                                     maybe_fetch_metadata=maybe_fetch_metadata,
-                                     light=light)
+    if light:
+      info_data = await get_model_info(lora_file,
+                                       maybe_fetch_civitai=maybe_fetch_civitai,
+                                       maybe_fetch_metadata=maybe_fetch_metadata,
+                                       light=light)
+    else:
+      info_data = await get_model_info(lora_file,
+                                       force_fetch_civitai=maybe_fetch_civitai,
+                                       force_fetch_metadata=maybe_fetch_metadata,
+                                       light=light)
     if info_data is None:
       api_response['status'] = '404'
       api_response['error'] = 'No Lora found at path'


### PR DESCRIPTION
Fixes #10
异常原因是获取的数据不完整，代码没有判断数据完整性，这里我用强制刷新重新获取信息。

还有就是刷新按钮的优先级太低，`get_model_info`函数的`should_fetch_civitai`变量获取时加个内容判断也能正常刷新。

第三就是`light`轻量加载的逻辑我不太明白，按我的理解是点开信息页时使用本地数据，刷新时使用C站数据，但实际`light = not is_param_falsy(request, 'light')`并没有获取到正确的布尔值，打开信息页`weilin/lorainfo/api/loras/info`携带了参数`light: 0`，`is_param_falsy`返回True，加了`not`变为False，关闭轻量加载，刷新按钮`weilin/lorainfo/api/loras/refresh`没有携带`light`参数，反而开启了轻量加载，而且应该`light: 1`是开启，`light: 0`是关闭才符合逻辑吧，但我只会python，不会改前端，我应该没有理解错逻辑吧