### PR TITLE
自动获取lora模型信息和封面图片

### DIFF
--- a/script/lorainfo.py
+++ b/script/lorainfo.py
@@ -298,9 +298,9 @@ async def get_model_info(file: str,
   should_save = _update_data(info_data) or should_save
 
   should_fetch_civitai = force_fetch_civitai is True or (maybe_fetch_civitai is True and
-                                                         'civitai' not in info_data['raw'])
+                                                         ('civitai' not in info_data['raw'] or len(info_data['raw']['civitai']) == 0))
   should_fetch_metadata = force_fetch_metadata is True or (maybe_fetch_metadata is True and
-                                                           'metadata' not in info_data['raw'])
+                                                           ('metadata' not in info_data['raw'] or len(info_data['raw']['metadata']) == 0))
 
   if should_fetch_metadata:
     data_meta = _get_model_metadata(file,

--- a/sd_webui_prompt_all_in_one_app/sd_webui_prompt_all_in_one/scripts/on_app_started.py
+++ b/sd_webui_prompt_all_in_one_app/sd_webui_prompt_all_in_one/scripts/on_app_started.py
@@ -420,7 +420,7 @@ def on_app_started(_: gr.Blocks):
 
     @PromptServer.instance.routes.get("/weilin/physton_prompt/get_extra_networks")
     async def _get_extra_networks(request):
-        return web.json_response({"extra_networks": await get_extra_networks()})
+        return web.json_response({"extra_networks": await get_extra_networks(auto_fetch=True)})
 
     @PromptServer.instance.routes.post("/weilin/physton_prompt/gen_openai")
     async def _gen_openai(request):

--- a/sd_webui_prompt_all_in_one_app/sd_webui_prompt_all_in_one/scripts/physton_prompt/get_extra_networks.py
+++ b/sd_webui_prompt_all_in_one_app/sd_webui_prompt_all_in_one/scripts/physton_prompt/get_extra_networks.py
@@ -8,6 +8,10 @@ from PIL import Image
 import base64
 from io import BytesIO
 from pathlib import Path
+import requests
+import asyncio
+import concurrent.futures
+from tqdm import tqdm
 
 Path = os.path.join(os.path.dirname(__file__), "../../../../")
 sys.path.append(Path)
@@ -26,7 +30,59 @@ def quote_js(s):
     s = s.replace('"', '\\"')
     return f'"{s}"'
 
-async def get_extra_networks():
+def download_image(url, filename, directory):
+    _, ext = os.path.splitext(url)
+    filename, _ = os.path.splitext(filename)
+    filepath = os.path.join(directory, f"{filename}{ext}")
+    try:
+        resp = requests.get(url, stream=True)
+        resp.raise_for_status()
+        with open(filepath, 'wb') as f:
+             for chunk in resp.iter_content(chunk_size=4096):
+                 f.write(chunk)
+    except Exception as e:
+        print(e)
+        if os.path.exists(filepath):
+            os.remove(filepath)
+
+def prepare_lora_item_data(item_path, auto_fetch=False):
+    lora_path = folder_paths.get_full_path("loras", item_path)
+    [model_name, model_extension] = os.path.splitext(item_path)
+    file_name = os.path.basename(item_path)
+    info_data = asyncio.run(get_model_info(item_path, light=True))
+    if auto_fetch:
+        if len(info_data['images']) == 0: # 无数据
+            info_data = asyncio.run(get_model_info(item_path, maybe_fetch_civitai=True, maybe_fetch_metadata=True, light=False))
+        if len(info_data['images']) != 0 and item_path not in info_data['images'][0]['url']: # 未设置封面
+            url = next(filter(lambda x: x['type'] == 'image', info_data['images']), {}).get('url')
+            download_image(url=url, filename=file_name, directory=os.path.dirname(lora_path))
+
+    item = {
+            "basename": item_path,
+            "name": item_path,
+            "dirname": os.path.dirname(lora_path),
+            "filename": lora_path,
+            "description": "",
+            "preview":preview_file(lora_path),
+            "model_name": model_name,
+            "model_type": "loras",
+            "model_filename": file_name,
+            # "shorthash": lora_on_disk.shorthash,
+            # "preview": self.find_preview(path),
+            # "description": self.find_description(path),
+            # "search_terms": search_terms,
+            # "local_preview": f"{path}.{shared.opts.samples_format}",
+            # "metadata": lora_on_disk.metadata,
+            # "sort_keys": {'default': index, **self.get_sort_keys(lora_on_disk.filename)},
+            # "sd_version": lora_on_disk.sd_version.name,
+        }
+    # item["prompt"] = quote_js(f"<lora:{item_path}:1") + quote_js(">")
+    item["prompt"] = f"<lora:{item_path}:"
+    item["local_info"] = info_data
+    # item["search_terms"] = ["Lora\\"+item_path]
+    return item
+
+async def get_extra_networks(auto_fetch=False):
     loras_path  = folder_paths.get_filename_list("loras")
     result = []
     result_item = {
@@ -35,37 +91,10 @@ async def get_extra_networks():
         'items': []
     }
     items = []
-    for item_path in loras_path:
-        lora_path = folder_paths.get_full_path("loras", item_path)
-        [model_name, model_extension] = os.path.splitext(item_path)
-        file_name = os.path.basename(item_path)
-        # 获取个人的设置信息如果有的话
-        info_data = await get_model_info(item_path,light = True)
-        
-        item = {
-                "basename": item_path,
-                "name": item_path,
-                "dirname": os.path.dirname(lora_path),
-                "filename": lora_path,
-                "description": "",
-                "preview":preview_file(lora_path),
-                "model_name": model_name,
-                "model_type": "loras",
-                "model_filename": file_name,
-                # "shorthash": lora_on_disk.shorthash,
-                # "preview": self.find_preview(path),
-                # "description": self.find_description(path),
-                # "search_terms": search_terms,
-                # "local_preview": f"{path}.{shared.opts.samples_format}",
-                # "metadata": lora_on_disk.metadata,
-                # "sort_keys": {'default': index, **self.get_sort_keys(lora_on_disk.filename)},
-                # "sd_version": lora_on_disk.sd_version.name,
-            }
-        # item["prompt"] = quote_js(f"<lora:{item_path}:1") + quote_js(">")
-        item["prompt"] = f"<lora:{item_path}:"
-        item["local_info"] = info_data
-        # item["search_terms"] = ["Lora\\"+item_path]
-        items.append(item)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()*2) as executor:
+        futures = [executor.submit(prepare_lora_item_data, item_path, auto_fetch) for item_path in loras_path]
+        for future in tqdm(futures):
+            items.append(future.result())
     result_item['items'] = items
     result.append(result_item)
     return result


### PR DESCRIPTION
自动加载模型信息和下载封面，如果模型较多那加载的时间会很长，我400个模型加载5分钟左右，因为要计算模型哈希值和下载封面。

加载的线程数是2倍CPU线程数，加载时会出现很多`HTTPSConnectionPool(host='civitai.com', port=443): Max retries exceeded with url:xxx`这样的报错，不用管，并发数太多肯定会出现错误的，第一次加载完成后再点击一次`刷新PromptUI`重新下载报错的模型应该就好了。

默认是选择模型页面的第一张图片作为封面。